### PR TITLE
Set start_once for new narrative services

### DIFF
--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -258,6 +258,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     cookie = u'{}'.format(session)
     labels = dict()
     labels["io.rancher.container.pull_image"] = u"always"
+    labels["io.rancher.container.start_once"] = u"true"
     labels["traefik.enable"] = u"True"
     labels["session_id"] = session
     rule = u"Host(\"{}\") && PathPrefix(\"{}\") && HeadersRegexp(\"Cookie\",`{}`)"


### PR DESCRIPTION
Set the start_once label on narrative services, so that if there's an error starting up, the container is just stopped, instead of looping between starting and crashing.