### PR TITLE
Status endpoint w/ custom role for full status report

### DIFF
--- a/app.py
+++ b/app.py
@@ -234,7 +234,7 @@ def valid_request(request: Dict[str, str]) -> str:
             authresponse = r.json()
             if r.status_code == 200:
                 auth_status['userid'] = authresponse['user']
-                auth_status['customroles'] = authresponse['user']
+                auth_status['customroles'] = authresponse['customroles']
             else:
                 auth_status['error'] = 'auth_error'
                 auth_status['message'] = authresponse['error']['message']


### PR DESCRIPTION

   This addresses Boris' suggestion that we use a custom role from auth2 for access to the full status response. It is currently set to look for the custom role KBASE_ADMIN.