### PR TITLE
Reaper cleanup

### DIFF
--- a/app.py
+++ b/app.py
@@ -173,7 +173,7 @@ def setup_app(app: flask.Flask) -> None:
             find_image = manage_rancher.find_image
             find_service = manage_rancher.find_service
             find_narratives = manage_rancher.find_narratives
-            find_narrative_labels = manage_rancher.narrative_labels
+            find_narrative_labels = manage_rancher.find_narrative_labels
             reap_narrative = manage_rancher.reap_narrative
             naming_regex = "^{}_"
         else:
@@ -184,7 +184,7 @@ def setup_app(app: flask.Flask) -> None:
             find_image = manage_docker.find_image
             find_service = manage_docker.find_service
             find_narratives = manage_docker.find_narratives
-            find_narrative_labels = manage_docker.narrative_labels
+            find_narrative_labels = manage_docker.find_narrative_labels
             reap_narrative = manage_docker.reap_narrative
             naming_regex = "^{}$"
     except Exception as ex:

--- a/app.py
+++ b/app.py
@@ -457,7 +457,7 @@ def reaper() -> None:
     try:
         zombies = find_stopped_services().keys()
         logger.debug({"message": "find_stopped_services() called", "num returned": len(zombies)})
-        reap_list.update(zombies)
+        reap_list.extend(zombies)
     except Exception as ex:
         logger.critical({"message": "Exception calling find_stopped_services", "Exception": repr(ex)})
 

--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ import logging
 from pythonjsonlogger import jsonlogger
 import sys
 import time
-import signal
 import re
 from datetime import datetime
 import json
@@ -15,7 +14,6 @@ import manage_docker
 import manage_rancher
 from apscheduler.schedulers.background import BackgroundScheduler
 from typing import Dict, List, Optional
-from types import FrameType
 
 VERSION = "0.9.2"
 
@@ -211,7 +209,7 @@ def setup_app(app: flask.Flask) -> None:
     narr_time = { narr+suffix: time.time() for narr in narrs if narr.startswith(prefix) }
     logger.debug({"message": "Adding containers matching {} to narr_activity".format(prefix), "names": str(list(narr_time.keys()))})
     narr_activity.update(narr_time)
-    
+
 
 
 def get_prespawned() -> List[str]:

--- a/app.py
+++ b/app.py
@@ -155,6 +155,7 @@ def setup_app(app: flask.Flask) -> None:
     # Verify that either docker or rancher configs are viable before continuing. It is a fatal error if the
     # configs aren't good, so bail out entirely and don't start the app. Set the global method pointers to
     # point at the right method - this will go away once the class based rewrite happens
+    global check_session
     global start
     global find_image
     global find_service

--- a/app.py
+++ b/app.py
@@ -101,7 +101,9 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
  
 
 def merge_env_cfg() -> None:
-    """ Go through the environment variables and and merge them into the global configuration. """
+    """
+    Go through the environment variables and and merge them into the global configuration.
+    """
     for cfg_item in cfg.keys():
         if cfg_item in os.environ:
             logger.info({"message": "Setting config from environment"})
@@ -136,7 +138,7 @@ def setup_app(app: flask.Flask) -> None:
 
     # Seed the random number generator based on default (time)
     random.seed()
- 
+
     merge_env_cfg()
 
     # Configure logging
@@ -219,7 +221,9 @@ def setup_app(app: flask.Flask) -> None:
 
 
 def get_prespawned() -> List[str]:
-    """ returns a list of the prespawned narratives waiting to be assigned """
+    """
+    Returns a list of the prespawned narratives waiting to be assigned
+    """
     if cfg["mode"] != "rancher":
         raise(NotImplementedError("prespawning only supports rancher mode, current mode={}".format(cfg['mode'])))
     narratives = manage_rancher.find_narratives()
@@ -228,7 +232,9 @@ def get_prespawned() -> List[str]:
 
 
 def prespawn_narrative(num: int) -> None:
-    """ Prespawn num narratives that incoming users can be assigned to immediately """
+    """
+    Prespawn num narratives that incoming users can be assigned to immediately
+    """
     logger.info({"message": "prespawning containers", "number": num})
     if cfg['mode'] != "rancher":
         raise(NotImplementedError("prespawning only supports rancher mode, current mode={}".format(cfg['mode'])))
@@ -397,7 +403,7 @@ def get_active_traefik_svcs() -> Dict[str, time.time]:
         else:
             raise(Exception("Error querying {}:{} {}".format(cfg['traefik_metrics'], r.status_code, r.text)))
     except Exception as e:
-        exc_type, exc_obj, tb = sys.exc_info()
+        _, _, tb = sys.exc_info()
         f = tb.tb_frame
         lineno = tb.tb_lineno
         filename = f.f_code.co_filename

--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from typing import Dict, List, Optional
 from types import FrameType
 
-VERSION = "0.9.1"
+VERSION = "0.9.2"
 
 # Setup default configuration values, overriden by values from os.environ later
 cfg = {"docker_url": u"unix://var/run/docker.sock",    # path to docker socket

--- a/logging.conf
+++ b/logging.conf
@@ -33,12 +33,18 @@ class=StreamHandler
 formatter=json_access
 args=(sys.stdout, )
 
+[handler_null_file]
+class=logging.FileHandler
+formatter=json_access
+args=('/dev/null', )
+
+
 [formatter_json]
 format=%(asctime)s %(name)s %(levelname)s %(message)s
 datefmt=%Y-%m-%dT%H:%M:%S%z
 class=pythonjsonlogger.jsonlogger.JsonFormatter
 
 [formatter_json_access]
-format=%(asctime)s %(name)s %(levelname)s %(message)s"
+format=%(asctime)s %(name)s %(levelname)s %(message)s
 datefmt=%Y-%m-%dT%H:%M:%S%z
 class=pythonjsonlogger.jsonlogger.JsonFormatter

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -353,14 +353,14 @@ def find_stopped_services() -> dict:
     Result can be an empty dictionary
     """
     stack_suffix = "_{}".format(cfg['rancher_stack_name'])
-    url = "{}/healthState=started-once".format(cfg['rancher_env_url'])
+    url = "{}/service?healthState=started-once".format(cfg['rancher_env_url'])
     r = requests.get(url, auth=(cfg['rancher_user'], cfg['rancher_password']))
     if r.ok:
         results = r.json()
         names = { svc['name']: svc for svc in results['data'] }
         return( names)
     else:
-        raise(Exception("Error querying for stopped services: Response code {}: {}".format(r.status_code, r.body)))
+        raise(Exception("Error querying for stopped services: Response code {}".format(r.status_code)))
 
 
 def find_image(name: str) -> str:

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -327,7 +327,7 @@ def find_stack() -> Dict[str, str]:
 
 
 def stack_suffix() -> str:
-    """ Returns the stack suffix that traefik appends to service names """
+    """ Returns the stack suffix that traefik appends to service names. """
     return("_{}".format(cfg['rancher_stack_name']))
 
 

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -347,6 +347,22 @@ def find_service(traefikname: str) -> dict:
         raise(Exception("Error querying for {}: Response code {}: {}".format(name, r.status_code, r.body)))
 
 
+def find_stopped_service() -> dict:
+    """
+    Query rancher for services with the state "healthState=started-once" and return the names of matching services
+    Result can be an empty dictionary
+    """
+    stack_suffix = "_{}".format(cfg['rancher_stack_name'])
+    url = "{}/healthState=started-once".format(cfg['rancher_env_url'])
+    r = requests.get(url, auth=(cfg['rancher_user'], cfg['rancher_password']))
+    if r.ok:
+        results = r.json()
+        names = { svc['name']: svc for svc in results['data'] }
+        return( names)
+    else:
+        raise(Exception("Error querying for stopped services: Response code {}: {}".format(r.status_code, r.body)))
+
+
 def find_image(name: str) -> str:
     """
     Given a service name, return the docker image that the service is running. If the service doesn't exist

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -327,7 +327,7 @@ def find_stack() -> Dict[str, str]:
 
 
 def stack_suffix() -> str:
-    """ returns the stack suffix that traefik appends to service names """
+    """ Returns the stack suffix that traefik appends to service names """
     return("_{}".format(cfg['rancher_stack_name']))
 
 

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -327,7 +327,9 @@ def find_stack() -> Dict[str, str]:
 
 
 def stack_suffix() -> str:
-    """ Returns the stack suffix that traefik appends to service names. """
+    """
+    Returns the stack suffix that traefik appends to service names.
+    """
     return("_{}".format(cfg['rancher_stack_name']))
 
 

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -347,7 +347,7 @@ def find_service(traefikname: str) -> dict:
         raise(Exception("Error querying for {}: Response code {}: {}".format(name, r.status_code, r.body)))
 
 
-def find_stopped_service() -> dict:
+def find_stopped_services() -> dict:
     """
     Query rancher for services with the state "healthState=started-once" and return the names of matching services
     Result can be an empty dictionary


### PR DESCRIPTION
This branch fixes a bunch of residual problems in the reaper:
1) The reaper process depends entirely on the traefik metrics to identify what services are candidates for reaping. If Traefik is restarted after a pre-existing narrative has gone idle, then there will be no trace of the idle narrative in the traefik narratives and it won't get reaped
2) Narratives can fail at startup and end up in the "started-once" state for a user. This will block a user from starting a new narrative because the old narrative is parked on that narrative name.

There is also a good bit of code cleanup around repeated boilerplate and removal of no longer functioning signal handler.