### PR TITLE
Fix logname

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ cfg = {"docker_url": u"unix://var/run/docker.sock",    # path to docker socket
        "narr_img": "kbase/narrative",                  # string used to match images of services/containers for reaping
        "traefik_metrics": "http://traefik:8080/metrics",  # URL of traefik metrics endpoint, api + prometheus must be enabled
        "dock_net": u"narrative-traefiker_default",     # name of the docker network that docker containers should be bound to
-       "log_level": logging.DEBUG,                     # loglevel
+       "log_level": logging.DEBUG,                     # loglevel - DEBUG=10, INFO=20, WARNING=30, ERROR=40, CRITICAL=50
        "log_dest": None,                               # log destination - currently unused
        "log_name": u"traefiker",                       # python logger name
        "rancher_user": None,                           # username for rancher creds

--- a/logging.conf
+++ b/logging.conf
@@ -30,7 +30,7 @@ args=(sys.stdout, )
 
 [handler_access_file]
 class=StreamHandler
-formatter=json_access
+formatter=json
 args=(sys.stdout, )
 
 [handler_null_file]

--- a/logging.conf
+++ b/logging.conf
@@ -40,7 +40,7 @@ args=('/dev/null', )
 
 
 [formatter_json]
-format=%(timestamp)s %(name)s %(level)s %(message)s %(type)s
+format=%(name)s %(level)s %(message)s %(type)s %(timestamp)s
 datefmt=%Y-%m-%dT%H:%M:%S%z
 class=CustomJsonFormatter.CustomJsonFormatter
 

--- a/manage_docker.py
+++ b/manage_docker.py
@@ -106,7 +106,7 @@ def check_session(userid: str) -> str:
         session_id = None
     except docker.errors.APIErrors as err:
         msg = "Docker APIError thrown while searching for container name {} : {}".format(name, str(err))
-        logger.error({"message": msg, "name": name, "exception": str(err)})
+        logger.error({"message": msg, "container_name": name, "exception": str(err)})
         session_id = None
     return(session_id)
 
@@ -131,7 +131,7 @@ def start(session: str, userid: str) -> Dict[str, str]:
         name = cfg['container_name'].format(userid)
         container = client.containers.run(cfg['image'], detach=True, labels=labels, hostname=name,
                                           auto_remove=True, name=name, network=cfg["dock_net"])
-        logger.info({"message": "new_container", "image": cfg['image'], "userid": userid, "name": name,
+        logger.info({"message": "new_container", "image": cfg['image'], "userid": userid, "container_name": name,
                     "session_id": session})
     except docker.errors.APIError as err:
         # If there is a race condition because a container has already started, then this should catch it.
@@ -140,7 +140,7 @@ def start(session: str, userid: str) -> Dict[str, str]:
         if session is None:
             raise(err)
         else:
-            logger.info({"message": "previous_session", "userid": userid, "name": name, "session_id": session})
+            logger.info({"message": "previous_session", "userid": userid, "container_name": name, "session_id": session})
             container = client.get_container(name)
     if container.status != u"created":
         raise(Exception("Error starting container: container status {}".format(container.status)))

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -73,12 +73,12 @@ def check_session(userid: str) -> str:
         r = requests.get(url, auth=(cfg["rancher_user"], cfg["rancher_password"]))
         if not r.ok:
             msg = "Error response code from rancher API while searching for container name {} : {}".format(name, r.status_code)
-            logger.error({"message": msg, "status_code": r.status_code, "name": name, "response_body": r.text})
+            logger.error({"message": msg, "status_code": r.status_code, "service_name": name, "response_body": r.text})
             raise(Exception(msg))
         res = r.json()
         svcs = res['data']
         if len(svcs) == 0:
-            logger.debug({"message": "No previous session found", "name": name, "userid": userid})
+            logger.debug({"message": "No previous session found", "service_name": name, "userid": userid})
             session_id = None
         else:
             session_id = svcs[0]['launchConfig']['labels']['session_id']
@@ -86,7 +86,7 @@ def check_session(userid: str) -> str:
             if len(svcs) > 1:
                 uuids = [svc['uuid'] for svc in svcs]
                 logger.warning({"message": "Found multiple session matches against container name", "userid": userid,
-                               "name": name, "rancher_uuids": uuids})
+                               "service_name": name, "rancher_uuids": uuids})
     except Exception as ex:
         logger.debug({"message": "Error trying to find existing session", "exception": format(str(ex)), "userid": userid})
         raise(ex)
@@ -122,11 +122,11 @@ def start(session: str, userid: str, prespawn: Optional[bool] = False) -> Dict[s
                     rename_narrative(candidate, narr_name)
                     container = find_service(narr_name)
                     session = container['launchConfig']['labels']['session_id']
-                    logger.info({"message": "assigned_container", "userid": userid, "name": narr_name, "session_id": session,
+                    logger.info({"message": "assigned_container", "userid": userid, "service_name": narr_name, "session_id": session,
                                  "client_ip": "127.0.0.1", "attempt": attempt, "status": "success"})
                     break
                 except Exception as ex:
-                    logger.info({"message": "assigned_container_fail", "userid": userid, "name": narr_name, "session_id": session,
+                    logger.info({"message": "assigned_container_fail", "userid": userid, "service_name": narr_name, "session_id": session,
                                  "client_ip": "127.0.0.1", "attempt": attempt, "status": "fail", "error": str(ex)})
             if session:
                 return({"session": session, "prespawned": True})
@@ -289,7 +289,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     # an error state, and overwrite the response with an error response
     try:
         r = requests.post(cfg["rancher_env_url"]+"/service", json=container_config, auth=(cfg["rancher_user"], cfg["rancher_password"]))
-        logger.info({"message": "new_container", "image": cfg['image'], "userid": userid, "name": name, "session_id": session,
+        logger.info({"message": "new_container", "image": cfg['image'], "userid": userid, "service_name": name, "session_id": session,
                     "client_ip": client_ip})  # request.remote_addr)
         if not r.ok:
             msg = "Error - response code {} while creating new narrative rancher service: {}".format(r.status_code, r.text)


### PR DESCRIPTION
Fixes a couple of minor things in the logging:
1) The gunicorn access log was formatted differently, brought that in line with the rest of the logs
2) Added some numeric guidelines to the comments around log_level config
3) Altered ordering of log output fields to the rancher console so that more useful information is available in the main viewport