### PR TITLE
Highlander - There can be only one!

### DIFF
--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -108,10 +108,12 @@ def start(session: str, userid: str, prespawn: Optional[bool] = False) -> Dict[s
         # usage there might be spike that exhausts the pool of ready containers before replacements
         # are available.
         if len(prespawned) > 0:
-            # Spawn a replacement and immediately rename an existing container to match the
+            # if we're not already over the num)prespawn setting then
+            # spawn a replacement and immediately rename an existing container to match the
             # userid. We are replicating the prespawn container name code here, maybe cause
             # issues later on if the naming scheme is changed!
-            start_new(session, session[0:6], True)
+            if len(prespawned) <= cfg['num_prespawn']:
+                start_new(session, session[0:6], True)
             narr_name = cfg['container_name'].format(userid)
             offset = random.randint(0, len(prespawned)-1)
             session = None


### PR DESCRIPTION
This PR addresses problems with:
1) Race conditions that allow more than 1 narrative to be spun up in rancher. When multiple narratives of the same name are detected, all but the first are removed
2) Lack of exception handling in the narrative_status handler. Updated to deal with errors from duplicate names, but will still throw an exception if there is a problem querying for rancher. This is so that if the service has such a basic issue talking to rancher, it shows up as an error when querying the status page.
3) If there are already more prespawned narratives than required, then do not spawn a new narrative when assigning existing narratives to a new user.