### PR TITLE
Drop capabilities

### DIFF
--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -160,7 +160,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
                         u'launchConfig':   {
                             u'blkioWeight': None,
                             u'capAdd': [],
-                            u'capDrop': ["NET_RAW"],
+                            u'capDrop': ["MKNOD","NET_RAW","SYS_CHROOT"],
                             u'cgroupParent': None,
                             u'count': None,
                             u'cpuCount': None,

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -160,7 +160,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
                         u'launchConfig':   {
                             u'blkioWeight': None,
                             u'capAdd': [],
-                            u'capDrop': ['NET_RAW','CHOWN'],
+                            u'capDrop': ["CHOWN","NET_RAW"],
                             u'cgroupParent': None,
                             u'count': None,
                             u'cpuCount': None,

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -148,7 +148,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     method, with the equivalent rancher exceptions.
     """
     # Crazy long config needed for rancher container startup. Based on observing the traffic from rancher
-    # GUI to rancher REST APIs. Might be able to prune it down with some re
+    # GUI to rancher REST APIs. Might be able to prune it down with some research
     container_config = {u'assignServiceIpAddress': False,
                         u'createIndex': None,
                         u'created': None,
@@ -160,7 +160,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
                         u'launchConfig':   {
                             u'blkioWeight': None,
                             u'capAdd': [],
-                            u'capDrop': [],
+                            u'capDrop': ['CAP_NET_RAW','CAP_CHOWN'],
                             u'cgroupParent': None,
                             u'count': None,
                             u'cpuCount': None,

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -160,7 +160,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
                         u'launchConfig':   {
                             u'blkioWeight': None,
                             u'capAdd': [],
-                            u'capDrop': ["CHOWN","NET_RAW"],
+                            u'capDrop': ["NET_RAW"],
                             u'cgroupParent': None,
                             u'count': None,
                             u'cpuCount': None,
@@ -254,6 +254,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
                         u'selectorLink': None,
                         u'stackId': None,
                         u'startOnCreate': True,
+                        u'system': False,
                         u'type': u'service',
                         u'uuid': None,
                         u'vip': None}

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -160,7 +160,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
                         u'launchConfig':   {
                             u'blkioWeight': None,
                             u'capAdd': [],
-                            u'capDrop': ['CAP_NET_RAW','CAP_CHOWN'],
+                            u'capDrop': ['NET_RAW','CHOWN'],
                             u'cgroupParent': None,
                             u'count': None,
                             u'cpuCount': None,


### PR DESCRIPTION
After a bunch of testing, it seems that mknod, new_raw and chroot are safe to drop. Tried chown and that was a fail, setuid and setgid are needed for creation of some config files at startup. Once we can tweak the narrative image's file ownership to not need root access at startup, we can drop them as well.