### PR TITLE
Fix trailing underscore usernames

### DIFF
--- a/app.py
+++ b/app.py
@@ -302,7 +302,8 @@ def clean_userid( userid: str) -> str:
     """
     hash = hashlib.sha1(userid.encode()).hexdigest()
     hash = hash[:6]
-    cleaned = re.sub('[\._-]+', '-', userid)
+    clean1 = re.sub('[\._-]+', '-', userid)
+    cleaned = re.sub('-$', '-0', clean1)
     max_len = 62 - len(cfg['container_name']) - len(hash)
     cleaned = "{}-{}".format(cleaned[:max_len], hash)
     return(cleaned)


### PR DESCRIPTION
Usernames that end in _ are cleaned to end in -, but that makes a Rancher service name with -- which Rancher 1.x doesn't like.  This change replaces a trailing - in the cleaned userid with -0.  So user_name_ would before produce a Rancher service name like 'user-name--hash' but now is like 'user-name-0-hash'.