### PR TITLE
Add basic access control to /reaper/

### DIFF
--- a/app.py
+++ b/app.py
@@ -603,7 +603,7 @@ def reaper_endpoint():
     Endpoint that just runs the reaper once and returns the status
     """
 
-    request = flast.request
+    request = flask.request
     logger.info({"message": "Reaper endpoint called from {}".format(request.remote_addr)})
 
     resp = flask.Response("generic Reaper response")

--- a/app.py
+++ b/app.py
@@ -607,7 +607,6 @@ def reaper_endpoint():
     request = flask.request
     logger.info({"message": "Reaper endpoint called from {}".format(request.remote_addr)})
 
-    resp = flask.Response("generic Reaper response")
     if (ipaddress.ip_address(request.remote_addr) in ipaddress.ip_network(cfg['reaper_ipnetwork']) ):
         try:
             num = reaper()

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ import hashlib
 import manage_docker
 import manage_rancher
 from typing import Dict, List, Optional
+import ipaddress
 
 VERSION = "0.9.6"
 
@@ -41,7 +42,7 @@ cfg = {"docker_url": u"unix://var/run/docker.sock",    # path to docker socket
        "rancher_stack_name": None,                     # rancher stack name value, used with rancher_env_url - self-configured if not set, required if rancher_stack_id set
        "mode": None,                                   # What orchestation type? "rancher" or "docker"
        "reaper_timeout_secs": 600,                     # How long should a container be idle before it gets reaped?
-       "reaper_allowed_ip": u"127.0.0.1",              # What IP address is allowed to access /reaper/ ?
+       "reaper_ipnetwork": u"127.0.0.1/32",            # What IP address/network is allowed to access /reaper/ ?
        "debug": 0,                                     # Set debug mode
        "narrenv": dict(),                              # Dictionary of env name/val to be passed to narratives at startup
        "num_prespawn": 5,                              # How many prespawned narratives should be maintained? Checked at startup and reapee runs
@@ -607,7 +608,7 @@ def reaper_endpoint():
     logger.info({"message": "Reaper endpoint called from {}".format(request.remote_addr)})
 
     resp = flask.Response("generic Reaper response")
-    if (cfg['reaper_allowed_ip'] == request.remote_addr or cfg['reaper_allowed_ip'] == "0.0.0.0"):
+    if (ipaddress.ip_address(request.remote_addr) in ipaddress.ip_network(cfg['reaper_ipnetwork']) ):
         try:
             num = reaper()
             resp = flask.Response("Reaper success: {} deleted".format(num))


### PR DESCRIPTION
Compare remote_addr to reaper_allowed_ip, forbid request if it doesn't match.  (Can use 0.0.0.0 to allow /reaper/ from anywhere.)