### PR TITLE
[WIP] add sqlite database to track narrative activity

### DIFF
--- a/app.py
+++ b/app.py
@@ -197,9 +197,9 @@ def setup_app(app: flask.Flask) -> None:
     logger.info({'message': "using sqlite3 database in {}".format(cfg['sqlite_reaperdb_path'])})
     with app.app_context():
         db = get_db()
-    cursor = db.cursor()
-    cursor.execute('CREATE TABLE IF NOT EXISTS narr_activity (servicename TEXT PRIMARY KEY, lastseen FLOAT)')
-    db.commit()
+        cursor = db.cursor()
+        cursor.execute('CREATE TABLE IF NOT EXISTS narr_activity (servicename TEXT PRIMARY KEY, lastseen FLOAT)')
+        db.commit()
        
     # Prepopulate the narr_activity dictionary with current narratives found
     global narr_activity

--- a/app.py
+++ b/app.py
@@ -400,7 +400,7 @@ def get_container(dirty_user: str, request: flask.Request, narrative: str) -> fl
 def get_active_traefik_svcs(narr_activity) -> Dict[str, time.time]:
     """
     Looks through the traefik metrics endpoint results to find active websockets for narratives, and returns
-    a dictionary identical in structure to the global narr_activity, which can be used to update() narr_activity
+    a dictionary identical in structure to the narr_activity structure used in reaper() .
     """
 
     try:
@@ -425,7 +425,7 @@ def get_active_traefik_svcs(narr_activity) -> Dict[str, time.time]:
                     logger.debug({"message": "Matches prefix"})
                     image_name = find_image(name)
                     # Filter out any container that isn't the image type we are reaping
-                    if (cfg['narr_img'] in image_name):
+                    if (image_name is not None and cfg['narr_img'] in image_name):
                         logger.debug({"message": "Matches image name"})
                         # only update timestamp if the container has active websockets or this is the first
                         # time we've seen it.

--- a/app.py
+++ b/app.py
@@ -140,7 +140,7 @@ def delete_from_narr_activity_db(servicename: str) -> int:
     """
     conn = get_db()
     cursor = conn.cursor()
-    cursor.execute("DELETE FROM narr_activity WHERE servicename = ?", servicename)
+    cursor.execute("DELETE FROM narr_activity WHERE servicename = ?", [servicename])
     num_rows = cursor.rowcount
     conn.commit()
     return num_rows

--- a/app.py
+++ b/app.py
@@ -397,12 +397,11 @@ def get_container(dirty_user: str, request: flask.Request, narrative: str) -> fl
     return(resp)
 
 
-def get_active_traefik_svcs() -> Dict[str, time.time]:
+def get_active_traefik_svcs(narr_activity) -> Dict[str, time.time]:
     """
     Looks through the traefik metrics endpoint results to find active websockets for narratives, and returns
     a dictionary identical in structure to the global narr_activity, which can be used to update() narr_activity
     """
-    narr_activity = dict()
 
     try:
         r = requests.get(cfg['traefik_metrics'])
@@ -513,7 +512,7 @@ def reaper() -> int:
     log_info = { k : datetime.utcfromtimestamp(narr_activity[k]).isoformat() for k in narr_activity.keys() }
     logger.info({"message": "Reaper function running", "narr_activity": str(log_info)})
     try:
-        newtimestamps = get_active_traefik_svcs()
+        newtimestamps = get_active_traefik_svcs(narr_activity)
         narr_activity.update(newtimestamps)
     except Exception as e:
         logger.critical({"message": "ERROR: {}".format(repr(e))})

--- a/app.py
+++ b/app.py
@@ -123,6 +123,19 @@ def get_db():
     return db
 
 
+def get_narr_activity_from_db() -> Dict[ str, float ]:
+    """
+    Helper function for querying the database for narrative activity
+    and returning as a dict.
+    """
+    conn = get_db()
+    cursor = conn.cursor()
+    narr_activity = dict()
+    for row in cursor.execute('select * from narr_activity'):
+        narr_activity[row['servicename']] = row['lastseen']
+    return narr_activity
+
+
 @app.teardown_appcontext
 def close_connection(exception):
     """
@@ -224,7 +237,7 @@ def setup_app(app: flask.Flask) -> None:
         db = get_db()
         cursor = db.cursor()
         cursor.execute('CREATE TABLE IF NOT EXISTS narr_activity (servicename TEXT PRIMARY KEY, lastseen FLOAT)')
-        cursor.executemany('insert or replace into narr_activity values (?,?)',new_activity)
+        cursor.executemany('INSERT OR REPLACE INTO narr_activity VALUES (?,?)', new_activity)
         db.commit()
 
 
@@ -479,11 +492,7 @@ def reaper() -> int:
 
     # Get narr_activity from the database
     try:
-        conn = get_db()
-        cursor = conn.cursor()
-        narr_activity = dict()
-        for row in cursor.execute('select * from narr_activity'):
-            narr_activity[row['servicename']] = row['lastseen']
+        narr_activity = get_narr_activity_from_db()
     except Exception as e:
         logger.critical({"message": "Could not get data from database: {}".format(repr(e))})
         return

--- a/app.py
+++ b/app.py
@@ -61,7 +61,8 @@ logger: logging.Logger = logging.getLogger()
 app: flask.Flask = flask.Flask(__name__)
 
 # Dictionary containing narrative names and the last seen time
-narr_activity: Dict[str, time.time] = dict()
+# storing in db, removing global version
+# narr_activity: Dict[str, time.time] = dict()
 
 # The last version string seen for the narrative image
 narr_last_version = None

--- a/app.py
+++ b/app.py
@@ -524,7 +524,7 @@ def reaper() -> int:
         try:
             reap_narrative(name)
             # not currently using num_rows but may in the future
-            num_rows = delete_from_narr_activity_db(narr_activity[name])
+#            num_rows = delete_from_narr_activity_db(narr_activity[name])
             del narr_activity[name]
             reaped += 1
         except Exception as e:
@@ -538,6 +538,9 @@ def reaper() -> int:
         for key in narr_activity:
             new_activity.append((key, narr_activity[key] ))
         logger.info({"message": "Saving new narr_activity to database: {}".format(new_activity)})
+        # do we trust that the narr_activity dict has the right info?
+        # if so then it should be safe to delete the table contents and repopulate from it
+        cursor.execute("DELETE FROM narr_activity")
         cursor.executemany('INSERT OR REPLACE INTO narr_activity VALUES (?,?)',new_activity)
         conn.commit()
     except Exception as e:

--- a/app.py
+++ b/app.py
@@ -677,11 +677,12 @@ def narrative_status():
     logger.info({"message": "Status query received"})
 
     # Get narr_activity from the database
-    try:
-        narr_activity = get_narr_activity_from_db()
-    except Exception as e:
-        logger.critical({"message": "Could not get data from database: {}".format(repr(e))})
-        return
+    # not currently used but may use in the future
+#    try:
+#        narr_activity = get_narr_activity_from_db()
+#    except Exception as e:
+#        logger.critical({"message": "Could not get data from database: {}".format(repr(e))})
+#        return
 
     resp_doc = {"timestamp": datetime.now().isoformat(), "version": VERSION, "git_hash": cfg['COMMIT_SHA']}
     request = flask.request

--- a/app.py
+++ b/app.py
@@ -469,7 +469,13 @@ def reaper() -> int:
     Updates last seen timestamps for narratives, reaps any that have been idle for longer than cfg['reaper_timeout_secs']
     """
     global narr_last_version
-    global narr_activity
+
+    conn = get_db()
+    cursor = conn.cursor()
+    narr_activity = dict()
+    for row in cursor.execute('select * from narr_activity'):
+        narr_activity[row['servicename']] = row['lastseen']
+
     reaped = 0
     log_info = { k : datetime.utcfromtimestamp(narr_activity[k]).isoformat() for k in narr_activity.keys() }
     logger.info({"message": "Reaper function running", "narr_activity": str(log_info)})

--- a/app.py
+++ b/app.py
@@ -195,7 +195,8 @@ def setup_app(app: flask.Flask) -> None:
         prespawn_narrative(cfg['num_prespawn'])
 
     logger.info({'message': "using sqlite3 database in {}".format(cfg['sqlite_reaperdb_path'])})
-    db = get_db()
+    with app.app_context():
+        db = get_db()
     cursor = db.cursor()
     cursor.execute('CREATE TABLE IF NOT EXISTS narr_activity (servicename TEXT PRIMARY KEY, lastseen FLOAT)')
     db.commit()

--- a/app.py
+++ b/app.py
@@ -223,7 +223,7 @@ def setup_app(app: flask.Flask) -> None:
         prespawn_narrative(cfg['num_prespawn'])
 
     # Prepopulate the narr_activity dictionary with current narratives found
-    global narr_activity
+    narr_activity = dict()
     narrs = find_narratives()
     logger.debug({"message": "Found existing narrative containers at startup", "names": str(narrs)})
     prefix = cfg['container_name'].format('')
@@ -670,7 +670,8 @@ def narrative_status():
     list of ID's in cfg['status_users'] then a dump of the current narratives running and their last
     active time from narr_activity is returned in JSON form, ready to be consumed by a metrics service
     """
-    global narr_activity
+    # will need to retrieve this from database in the near future
+    narr_activity = dict()
     logger.info({"message": "Status query recieved"})
     resp_doc = {"timestamp": datetime.now().isoformat(), "version": VERSION, "git_hash": cfg['COMMIT_SHA']}
     request = flask.request

--- a/app.py
+++ b/app.py
@@ -109,7 +109,7 @@ def merge_env_cfg() -> None:
                          "key": "narrenv.{}".format(match.group(1)), "value": os.environ[k]})
 
 
-def get_db():
+def get_db() -> sqlite3.Connection:
     """
     Helper function for having flask get a database handle as needed
     """

--- a/app.py
+++ b/app.py
@@ -536,7 +536,7 @@ def reaper() -> int:
         cursor = conn.cursor()
         new_activity = list()
         for key in narr_activity:
-            new_activity.append((key,time.time()))
+            new_activity.append((key, narr_activity[key] ))
         logger.info({"message": "Saving new narr_activity to database: {}".format(new_activity)})
         cursor.executemany('INSERT OR REPLACE INTO narr_activity VALUES (?,?)',new_activity)
         conn.commit()

--- a/app.py
+++ b/app.py
@@ -250,19 +250,23 @@ def setup_app(app: flask.Flask) -> None:
     narr_activity.update(narr_time)
 
     # list to feed to execute()
-    new_activity = list()
-    for key in narr_activity:
-        new_activity.append((key,time.time()))
+#    new_activity = list()
+#    for key in narr_activity:
+#        new_activity.append((key,time.time()))
 
     logger.info({'message': "using sqlite3 database in {}".format(cfg['sqlite_reaperdb_path'])})
     # need this because we are not in a flask request context here
-    with app.app_context():
-        db = get_db()
-        cursor = db.cursor()
-        cursor.execute('CREATE TABLE IF NOT EXISTS narr_activity (servicename TEXT PRIMARY KEY, lastseen FLOAT)')
-        cursor.executemany('INSERT OR REPLACE INTO narr_activity VALUES (?,?)', new_activity)
-        db.commit()
-
+    try:
+        with app.app_context():
+            db = get_db()
+            cursor = db.cursor()
+            cursor.execute('CREATE TABLE IF NOT EXISTS narr_activity (servicename TEXT PRIMARY KEY, lastseen FLOAT)')
+            db.commit()
+#           cursor.executemany('INSERT OR REPLACE INTO narr_activity VALUES (?,?)', new_activity)
+            save_narr_activity_to_db(narr_activity)
+    except Exception as e:
+        logger.critical({"message": "Could not save initial narr_activity data to database: {}".format(repr(e))})
+ 
 
 def get_prespawned() -> List[str]:
     """

--- a/app.py
+++ b/app.py
@@ -525,6 +525,7 @@ def reaper() -> int:
             reap_narrative(name)
             # not currently using num_rows but may in the future
             num_rows = delete_from_narr_activity_db(narr_activity[name])
+            del narr_activity[name]
             reaped += 1
         except Exception as e:
             logger.critical({"message": "Error: Unhandled exception while trying to reap container {}: {}".format(name, repr(e))})

--- a/app.py
+++ b/app.py
@@ -123,19 +123,6 @@ def get_db():
     return db
 
 
-def get_narr_activity_from_db() -> Dict[ str, float ]:
-    """
-    Helper function for querying the database for narrative activity
-    and returning as a dict.
-    """
-    conn = get_db()
-    cursor = conn.cursor()
-    narr_activity = dict()
-    for row in cursor.execute('select * from narr_activity'):
-        narr_activity[row['servicename']] = row['lastseen']
-    return narr_activity
-
-
 @app.teardown_appcontext
 def close_connection(exception):
     """
@@ -492,7 +479,11 @@ def reaper() -> int:
 
     # Get narr_activity from the database
     try:
-        narr_activity = get_narr_activity_from_db()
+        conn = get_db()
+        cursor = conn.cursor()
+        narr_activity = dict()
+        for row in cursor.execute('select * from narr_activity'):
+            narr_activity[row['servicename']] = row['lastseen']
     except Exception as e:
         logger.critical({"message": "Could not get data from database: {}".format(repr(e))})
         return

--- a/app.py
+++ b/app.py
@@ -485,7 +485,7 @@ def reaper() -> int:
         for row in cursor.execute('select * from narr_activity'):
             narr_activity[row['servicename']] = row['lastseen']
     except Exception as e:
-        logger.critical({"Could not get data from database: {}".format(repr(e))})
+        logger.critical({"message": "Could not get data from database: {}".format(repr(e))})
         return
 
     reaped = 0
@@ -515,11 +515,11 @@ def reaper() -> int:
         new_activity = list()
         for key in narr_activity:
             new_activity.append((key,time.time()))
-        logger.info({"Saving new narr_activity to database: {}".format(new_activity)})
+        logger.info({"message": "Saving new narr_activity to database: {}".format(new_activity)})
         cursor.executemany('INSERT OR REPLACE INTO narr_activity VALUES (?,?)',new_activity)
         conn.commit()
     except Exception as e:
-        logger.critical({"Could not save data to database: {}".format(repr(e))})
+        logger.critical({"message": "Could not save data to database: {}".format(repr(e))})
 
     # Look for any containers that may have died on startup and reap them as well
     try:

--- a/app.py
+++ b/app.py
@@ -113,16 +113,16 @@ def merge_env_cfg() -> None:
 
 
 def get_db():
-    db = getattr(g, '_database', None)
+    db = getattr(flask.g, '_database', None)
     if db is None:
-        db = g._database = sqlite3.connect(cfg['sqlite_reaperdb_path'])
+        db = flask.g._database = sqlite3.connect(cfg['sqlite_reaperdb_path'])
     db.row_factory=sqlite3.Row
     return db
 
 
 @app.teardown_appcontext
 def close_connection(exception):
-    db = getattr(g, '_database', None)
+    db = getattr(flask.g, '_database', None)
     if db is not None:
         db.close()
 

--- a/app.py
+++ b/app.py
@@ -617,6 +617,11 @@ def narrative_shutdown(username=None):
                 # (this seems to not be matching anything for some reason)
                 # possible future work: use helper function to delete entry from narr_activity in db
                 name_match = naming_regex.format(name)
+                try:
+                    narr_activity = get_narr_activity_from_db()
+                except Exception as e:
+                    logger.critical({"message": "Could not get data from database: {}".format(repr(e))})
+                    raise(e)
                 for narr_name in narr_activity.keys():
                     if re.match(name_match, narr_name):
                         delete_from_narr_activity_db(narr_activity[narr_name])

--- a/app.py
+++ b/app.py
@@ -515,6 +515,9 @@ def reaper() -> int:
     except Exception as e:
         logger.critical({"message": "ERROR: {}".format(repr(e))})
         return
+    log_info = { k : datetime.utcfromtimestamp(narr_activity[k]).isoformat() for k in narr_activity.keys() }
+    logger.debug({"message": "Activity after updated from traefik: ", "narr_activity": str(log_info)})
+
     now = time.time()
     reap_list = [name for name, timestamp in narr_activity.items() if (now - timestamp) > cfg['reaper_timeout_secs']]
 
@@ -537,7 +540,7 @@ def reaper() -> int:
         new_activity = list()
         for key in narr_activity:
             new_activity.append((key, narr_activity[key] ))
-        logger.info({"message": "Saving new narr_activity to database: {}".format(new_activity)})
+        logger.debug({"message": "Saving new narr_activity to database: {}".format(new_activity)})
         # do we trust that the narr_activity dict has the right info?
         # if so then it should be safe to delete the table contents and repopulate from it
         cursor.execute("DELETE FROM narr_activity")

--- a/app.py
+++ b/app.py
@@ -402,6 +402,8 @@ def get_active_traefik_svcs() -> Dict[str, time.time]:
     Looks through the traefik metrics endpoint results to find active websockets for narratives, and returns
     a dictionary identical in structure to the global narr_activity, which can be used to update() narr_activity
     """
+    narr_activity = dict()
+
     try:
         r = requests.get(cfg['traefik_metrics'])
         if r.status_code == 200:

--- a/app.py
+++ b/app.py
@@ -515,8 +515,8 @@ def reaper() -> int:
         new_activity = list()
         for key in narr_activity:
             new_activity.append((key,time.time()))
-        logger.info("Saving new narr_activity to database: {}".format(new_activity)
-        cursor.executemany('insert or replace into narr_activity values (?,?)',new_activity)
+        logger.info({"Saving new narr_activity to database: {}".format(new_activity)})
+        cursor.executemany('INSERT OR REPLACE INTO narr_activity VALUES (?,?)',new_activity)
         conn.commit()
     except Exception as e:
         logger.critical({"Could not save data to database: {}".format(repr(e))})


### PR DESCRIPTION
Work in progress!  Please do not merge yet.

Adding SQLite3 support to track narrative activity.

Tasks:

- [x] create the database and table and populate on startup
- [x] retrieve from and save to the database in reaper()
- [x] remove narr_activity as a global
- [x] skip checking service if image_name is null in get_active_traefik_svcs()
- [x] retrieve from database in narrative_status() (narr_activity not even used there, just remove)
- [x] write helper function to save narrative activity to database
- [x] use helper functions in setup_app(), reaper(), narrative_shutdown(), and narrative_status()
- [ ] also save narrative_version to the db?  (optional)
- [ ] add docs to README (optional?)
- [ ] remove stale entries in reaper() (maybe just DELETE the table for now; optional to do one at a time)
- [ ] remove entry from database in narrative_shutdown(), fix narr_activity usage there (not hitting that code, come back later)
