### PR TITLE
Add last_seen back into status - needs to be updated for sqlite3

### DIFF
--- a/app.py
+++ b/app.py
@@ -547,16 +547,22 @@ def narrative_services() -> List[dict]:
     """
     Queries the rancher APIs to build a list of narrative container descriptors
     """
+    global narr_activity
     narr_names = find_narratives()
     narr_services = []
     prespawn_pre = cfg['container_name_prespawn'].format('')
     narr_pre = cfg['container_name'].format('')
     for name in narr_names:
         if name.startswith(prespawn_pre):
-            info = {"state": "queued", "session_id": "*", "instance": name}
+            info = {"state": "queued", "session_id": "*", "instance": name, 'last_seen': time.asctime() }
         else:
             user = name.replace(narr_pre, "", 1)
             info = {"instance": name, "state": "active", "session_id": user}
+            try:
+                info['last_seen'] = time.asctime(time.gmtime(narr_activity[name]))
+            except Exception as ex:
+                logger.critical({"message": "Error: adding last_seen field to status message", "error": repr(ex),
+                                 "container": name})
             try:
                 svc = find_service(name)
                 info['session_key'] = svc['launchConfig']['labels']['session_id']

--- a/app.py
+++ b/app.py
@@ -559,7 +559,7 @@ def narrative_services() -> List[dict]:
             user = name.replace(narr_pre, "", 1)
             info = {"instance": name, "state": "active", "session_id": user}
             try:
-                info['last_seen'] = time.asctime(time.gmtime(narr_activity[user]))
+                info['last_seen'] = time.asctime()
             except Exception as ex:
                 logger.critical({"message": "Error: adding last_seen field to status message", "error": repr(ex),
                                  "container": name})

--- a/app.py
+++ b/app.py
@@ -559,7 +559,7 @@ def narrative_services() -> List[dict]:
             user = name.replace(narr_pre, "", 1)
             info = {"instance": name, "state": "active", "session_id": user}
             try:
-                info['last_seen'] = time.asctime(time.gmtime(narr_activity[name]))
+                info['last_seen'] = time.asctime(time.gmtime(narr_activity[user]))
             except Exception as ex:
                 logger.critical({"message": "Error: adding last_seen field to status message", "error": repr(ex),
                                  "container": name})

--- a/app.py
+++ b/app.py
@@ -547,7 +547,6 @@ def narrative_services() -> List[dict]:
     """
     Queries the rancher APIs to build a list of narrative container descriptors
     """
-    global narr_activity
     narr_names = find_narratives()
     narr_services = []
     prespawn_pre = cfg['container_name_prespawn'].format('')
@@ -591,7 +590,6 @@ def narrative_status():
     list of ID's in cfg['status_users'] then a dump of the current narratives running and their last
     active time from narr_activity is returned in JSON form, ready to be consumed by a metrics service
     """
-    global narr_activity
     logger.info({"message": "Status query recieved"})
     resp_doc = {"timestamp": datetime.now().isoformat(), "version": VERSION, "git_hash": cfg['COMMIT_SHA']}
     request = flask.request


### PR DESCRIPTION
This is a hotfix to get the elasticsearch narrative_sessions working again - the last_seen field never got implemented. It also can't work right due to the issues with non-shared narr_activity. This is a patch just to get a value into the output. Will be followed with a PR to the sqlite_reaper that populated last_seen from the sqlite3 db