### PR TITLE
Reaper refactor

### DIFF
--- a/app.py
+++ b/app.py
@@ -436,10 +436,10 @@ def get_active_traefik_svcs(narr_activity) -> Dict[str, time.time]:
             except:
                 suffix = ""
             for name in containers.keys():
-                logger.debug({"message": "Examining container: {}".format(name)})
+                logger.debug({"message": "Examining traefik metrics entry: {}".format(name)})
                 # Skip any containers that don't match the container prefix, to avoid wasting time on the wrong containers
                 if name.startswith(prefix):
-                    logger.debug({"message": "Matches prefix"})
+                    logger.debug({"message": "Matches prefix {}".format(prefix)})
                     # services from traefik has a suffix which needs to be stripped to match
                     # against results from rancher API
                     if suffix and name.endswith(suffix):
@@ -448,12 +448,12 @@ def get_active_traefik_svcs(narr_activity) -> Dict[str, time.time]:
                         service_name = name
                     logger.debug({"message": "Looking for service named {}".format(service_name)})
                     if (service_name in all_narr_containers):
-                        logger.debug({"message": "Matches running service"})
+                        logger.debug({"message": "Found {}".format(service_name)})
                         # only update timestamp if the container has active websockets or this is the first
                         # time we've seen it.
                         if (containers[name] > 0) or (name not in narr_activity):
                             narr_activity[name] = time.time()
-                            logger.debug({"message": "Updated timestamp for "+name})
+                            logger.debug({"message": "Updated timestamp for {}".format(name)})
                     else:
                         logger.debug({"message": "Skipping because {} did not match running services".format(service_name)})
                 else:

--- a/app.py
+++ b/app.py
@@ -429,6 +429,8 @@ def get_active_traefik_svcs(narr_activity) -> Dict[str, time.time]:
             logger.debug({"message": "Looking for containers that with name prefix {} and image name {}".format(prefix, cfg['narr_img'])})
             # query for all of services in the environment that match cfg['narr_img'] as the image name
             all_narr_containers = find_narratives(cfg['narr_img'])
+            logger.debug({"message": "Results from find_narratives", "containers": all_narr_containers})
+
             try:
                 suffix = stack_suffix()
             except:

--- a/app.py
+++ b/app.py
@@ -438,12 +438,13 @@ def get_active_traefik_svcs(narr_activity) -> Dict[str, time.time]:
                 # Skip any containers that don't match the container prefix, to avoid wasting time on the wrong containers
                 if name.startswith(prefix):
                     logger.debug({"message": "Matches prefix"})
+                    # services from traefik has a suffix which needs to be stripped to match
+                    # against results from rancher API
                     if suffix and name.endswith(suffix):
                         service_name=name[:-len(suffix)]
                     else:
                         service_name = name
                     logger.debug({"message": "Looking for service named {}".format(service_name)})
-                    # Filter out any container that isn't the image type we are reaping
                     if (service_name in all_narr_containers):
                         logger.debug({"message": "Matches running service"})
                         # only update timestamp if the container has active websockets or this is the first

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -455,7 +455,6 @@ def find_narratives(image_name: Optional[str] = None) -> List[str]:
               r.status_code, r.body)))
     results = r.json()
     svcs = results['data']
-    logger.debug({"message": "results from rancher", "results": svcs})
     svc_names = [svc['name'] for svc in svcs if svc['launchConfig']['imageUuid'].startswith(imageUuid)]
     return(svc_names)
 

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -456,7 +456,7 @@ def find_narratives(image_name: Optional[str] = None) -> List[str]:
     results = r.json()
     svcs = results['data']
     logger.debug({"message": "results from rancher", "results": svcs})
-    svc_names = [svc['name'] for svc in svcs if svc['launchConfig']['imageUuid'] == imageUuid]
+    svc_names = [svc['name'] for svc in svcs if svc['launchConfig']['imageUuid'].startswith(imageUuid)]
     return(svc_names)
 
 

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -437,12 +437,14 @@ def find_prespawned() -> List[str]:
     return(idle_narr)
 
 
-def find_narratives() -> List[str]:
+def find_narratives(image_name: Optional[str] = None) -> List[str]:
     """
     This query hits the endpoint for the stack (cfg['rancher_stack_id']), and returns a list of all the
-    names of services that are have an imageUuid with a match for "docker:"+cfg['image'], this should
-    be any container running narratives
+    names of services that are have an imageUuid with a match for "docker:"+image_name. If no parameter is
+    given (the original function signature), then the default value of cfg['image'] is used.
     """
+    if image_name is None:
+        image_name = cfg['image']
     url = "{}/stacks/{}/services".format(cfg['rancher_env_url'], cfg['rancher_stack_id'])
     r = requests.get(url, auth=(cfg['rancher_user'], cfg['rancher_password']))
     if not r.ok:

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -447,12 +447,15 @@ def find_narratives(image_name: Optional[str] = None) -> List[str]:
         image_name = cfg['image']
     url = "{}/stacks/{}/services".format(cfg['rancher_env_url'], cfg['rancher_stack_id'])
     r = requests.get(url, auth=(cfg['rancher_user'], cfg['rancher_password']))
+    imageUuid = "docker:{}".format(image_name)
+    logger.debug({"message": "querying rancher for services matching {}".format(imageUuid)})
+
     if not r.ok:
         raise(Exception("Error querying for services at {}: Response code {}: {}".format(url,
               r.status_code, r.body)))
     results = r.json()
     svcs = results['data']
-    imageUuid = "docker:{}".format(image_name)
+    logger.debug({"message": "results from rancher", "results": svcs})
     svc_names = [svc['name'] for svc in svcs if svc['launchConfig']['imageUuid'] == imageUuid]
     return(svc_names)
 

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -452,7 +452,7 @@ def find_narratives(image_name: Optional[str] = None) -> List[str]:
               r.status_code, r.body)))
     results = r.json()
     svcs = results['data']
-    imageUuid = "docker:{}".format(cfg['image'])
+    imageUuid = "docker:{}".format(image_name)
     svc_names = [svc['name'] for svc in svcs if svc['launchConfig']['imageUuid'] == imageUuid]
     return(svc_names)
 


### PR DESCRIPTION
Rewrite the get_active_traefik_svcs() function to avoid wasteful API calls to traefik: use a single query to rancher to fetch all narrative containers services in a batch, instead of querying for each service individually. Update rancher find_narratives() to accept an optional parameter indicating what image name to match against instead of the default, and match the image name using prefix match instead of an exact match.