### PR TITLE
Adding GPR -> GHCR migration changes

### DIFF
--- a/.github/workflows/build_prodrc_pr.yaml
+++ b/.github/workflows/build_prodrc_pr.yaml
@@ -22,6 +22,6 @@ jobs:
       env:
         PR: "${{ github.event.pull_request.number }}"
         SHA: "${{ github.event.pull_request.head.sha }}"
-        DOCKER_ACTOR: "${{ github.actor }}"
-        DOCKER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        DOCKER_ACTOR: "jsfillman"
+        DOCKER_TOKEN: "${{ secrets.GHCR_TOKEN }}"
       run: "./.github/workflows/scripts/build_prodrc_pr.sh\n"

--- a/.github/workflows/build_test_pr.yaml
+++ b/.github/workflows/build_test_pr.yaml
@@ -22,6 +22,6 @@ jobs:
       env:
         PR: "${{ github.event.pull_request.number }}"
         SHA: "${{ github.event.pull_request.head.sha }}"
-        DOCKER_ACTOR: "${{ github.actor }}"
-        DOCKER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        DOCKER_ACTOR: "jsfillman"
+        DOCKER_TOKEN: "${{ secrets.GHCR_TOKEN }}"
       run: "./.github/workflows/scripts/build_test_pr.sh\n"

--- a/.github/workflows/scripts/build_prodrc_pr.sh
+++ b/.github/workflows/scripts/build_prodrc_pr.sh
@@ -1,15 +1,16 @@
 #! /usr/bin/env bash
 
-export MY_APP=$(echo "${GITHUB_REPOSITORY}"/$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//"))
+export MY_ORG=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $1}')
+export MY_APP=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')
 export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
 
-docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" docker.pkg.github.com
+docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
 docker build --build-arg BUILD_DATE="$DATE" \
              --build-arg COMMIT="$COMMIT" \
              --build-arg BRANCH="$GITHUB_HEAD_REF" \
              --build-arg PULL_REQUEST="$PR" \
              --label us.kbase.vcs-pull-req="$PR" \
-             -t docker.pkg.github.com/"$MY_APP":"pr-""$PR" .
-docker push docker.pkg.github.com/"$MY_APP":"pr-""$PR"
+             -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" .
+docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"

--- a/.github/workflows/scripts/build_test_pr.sh
+++ b/.github/workflows/scripts/build_test_pr.sh
@@ -1,15 +1,17 @@
 #! /usr/bin/env bash
 
-export MY_APP=$(echo "${GITHUB_REPOSITORY}"/$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//")"-develop")
+export MY_ORG=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $1}')
+export MY_APP=$(echo $(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')"-develop")
 export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
 
-docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" docker.pkg.github.com
+echo $DOCKER_TOKEN | docker login ghcr.io -u $DOCKER_ACTOR --password-stdin
 docker build --build-arg BUILD_DATE="$DATE" \
              --build-arg COMMIT="$COMMIT" \
              --build-arg BRANCH="$GITHUB_HEAD_REF" \
              --build-arg PULL_REQUEST="$PR" \
              --label us.kbase.vcs-pull-req="$PR" \
-             -t docker.pkg.github.com/"$MY_APP":"pr-""$PR" .
-docker push docker.pkg.github.com/"$MY_APP":"pr-""$PR"
+             -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" .
+docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
+	

--- a/.github/workflows/scripts/tag_environments.sh
+++ b/.github/workflows/scripts/tag_environments.sh
@@ -2,7 +2,8 @@
 #! /usr/bin/env bash
 # Add vars for PR & environments to yaml, as called from external script
 
-export MY_APP=$(echo "${GITHUB_REPOSITORY}"/$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//"))
+export MY_ORG=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $1}')
+export MY_APP=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')
 export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
@@ -15,7 +16,7 @@ else
 fi
 
 echo "Dev or Prod:" $DEV_PROD
-docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" docker.pkg.github.com
-docker pull docker.pkg.github.com/"$IMAGE":"$IMAGE_TAG"
-docker tag docker.pkg.github.com/"$IMAGE":"$IMAGE_TAG" docker.pkg.github.com/"$IMAGE":"$TARGET"
-docker push docker.pkg.github.com/"$IMAGE":"$TARGET"
+docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
+docker pull ghcr.io/"$MY_ORG"/"$IMAGE":"$IMAGE_TAG"
+docker tag ghcr.io/"$MY_ORG"/"$IMAGE":"$IMAGE_TAG" ghcr.io/"$MY_ORG"/"$IMAGE":"$TARGET"
+docker push ghcr.io/"$MY_ORG"/"$IMAGE":"$TARGET"

--- a/.github/workflows/scripts/tag_prod_latest.sh
+++ b/.github/workflows/scripts/tag_prod_latest.sh
@@ -1,11 +1,12 @@
 #! /usr/bin/env bash
 
-export MY_APP=$(echo "${GITHUB_REPOSITORY}"/$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//"))
+export MY_ORG=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $1}')
+export MY_APP=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')
 export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
 
-docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" docker.pkg.github.com
-docker pull docker.pkg.github.com/"$MY_APP":"pr-""$PR"
-docker tag docker.pkg.github.com/"$MY_APP":"pr-""$PR" docker.pkg.github.com/"$MY_APP":"latest"
-docker push docker.pkg.github.com/"$MY_APP":"latest"
+docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
+docker pull ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
+docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
+docker push ghcr.io/"$MY_ORG"/"$MY_APP":"latest"

--- a/.github/workflows/scripts/tag_test_latest.sh
+++ b/.github/workflows/scripts/tag_test_latest.sh
@@ -1,11 +1,12 @@
 #! /usr/bin/env bash
 
-export MY_APP=$(echo "${GITHUB_REPOSITORY}"/$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//")"-develop")
+export MY_ORG=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $1}')
+export MY_APP=$(echo $(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')"-develop")
 export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
 
-docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" docker.pkg.github.com
-docker pull docker.pkg.github.com/"$MY_APP":"pr-""$PR"
-docker tag docker.pkg.github.com/"$MY_APP":"pr-""$PR" docker.pkg.github.com/"$MY_APP":"latest"
-docker push docker.pkg.github.com/"$MY_APP":"latest"
+docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
+docker pull ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
+docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
+docker push ghcr.io/"$MY_ORG"/"$MY_APP":"latest"

--- a/.github/workflows/tag_environments.yaml
+++ b/.github/workflows/tag_environments.yaml
@@ -10,8 +10,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Tag Deploy Environments  
       env:
-        DOCKER_ACTOR: ${{ github.actor }}
-        DOCKER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DOCKER_ACTOR: jsfillman
+        DOCKER_TOKEN: ${{ secrets.GHCR_TOKEN  }}
         IMAGE_TAG: ${{ github.event.client_payload.image_tag }}
         SHA: ${{ github.event.pull_request.head.sha }}
         TARGET: ${{ github.event.client_payload.target }}

--- a/.github/workflows/tag_prod_latest.yaml
+++ b/.github/workflows/tag_prod_latest.yaml
@@ -21,6 +21,6 @@ jobs:
       env:
         PR: "${{ github.event.pull_request.number }}"
         SHA: "${{ github.event.pull_request.head.sha }}"
-        DOCKER_ACTOR: "${{ github.actor }}"
-        DOCKER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        DOCKER_ACTOR: "jsfillman"
+        DOCKER_TOKEN: "${{ secrets.GHCR_TOKEN }}"
       run: "./.github/workflows/scripts/tag_prod_latest.sh\n"

--- a/.github/workflows/tag_test_latest.yaml
+++ b/.github/workflows/tag_test_latest.yaml
@@ -21,6 +21,6 @@ jobs:
       env:
         PR: "${{ github.event.pull_request.number }}"
         SHA: "${{ github.event.pull_request.head.sha }}"
-        DOCKER_ACTOR: "${{ github.actor }}"
-        DOCKER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        DOCKER_ACTOR: "jsfillman"
+        DOCKER_TOKEN: "${{ secrets.GHCR_TOKEN }}"
       run: "./.github/workflows/scripts/tag_test_latest.sh\n"


### PR DESCRIPTION
Migrating from GitHub's Package Registry to the newer Container Service.

Primary Advantages are:

1. Allows unauthenticated pulls of public images (needed for our workflow)
2. Simplifies package naming & management
3. Improved org-wide package UI

Major Disadvantages is:

- The current implementation requires use of a personal access token stored as a GitHub Secret (vs the much more seamless GITHUB_TOKEN used by GPR). A future release of Container Registry will support GITHUB_TOKEN.