### PR TITLE
deploy images based on version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ The following environment variables should be in the startup environment:
 * rancher_url - endpoint for the rancher API, this service is currently written to use the "v2-beta" api
 * reaper_ipnetwork - one network that is allowed to access the /reaper/ endpoint
 
-Any config key in the cfg dictionary can be overridden by an environment variable.
+Any config key in the cfg dictionary in app.py can be overridden by an environment variable.  Some useful environment variables are:
+
+* narrative_version_url - a URL that returns the current version of the narrative.
+* image_name - the name of the image to be used to spawn narrative services in Rancher.  DO NOT include a :tag in this name.
+* image_tag - an optional variable to hardcode an image tag to use (omit the ':').  If not specified, defaults to whatever is returned by `narrative_version_url`.  Do not define image_tag with an empty value.
+* auth2 - a valid URL to /api/V2/me
+* status_role - an auth2 role that allows traefiker to return information about running narratives from the /narrative_status/ endpoint for debugging (otherwise only timestamp and traefiker version is returned)
 
 Any environment variable with the prefix "NARRENV_" will be passed to the narrative containers when they are started, with the "NARRENV_" prefix stripped out. For example, NARRENV_testvar="test" will result in testvar="test" being set in the startup for natrratives.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Any config key in the cfg dictionary in app.py can be overridden by an environme
 
 * narrative_version_url - a URL that returns the current version of the narrative.
 * image_name - the name of the image to be used to spawn narrative services in Rancher.  DO NOT include a :tag in this name.
-* image_tag - an optional variable to hardcode an image tag to use (omit the ':').  If not specified, defaults to whatever is returned by `narrative_version_url`.  Do not define image_tag with an empty value.
+* image_tag - an optional variable to hardcode an image tag to use (omit the ':').  If not specified, defaults to whatever is returned by `narrative_version_url`.  Do not define image_tag with an empty value or otherwise bad value (e.g., whitespace) or the services traefiker attempts to spin up will break.
 * auth2 - a valid URL to /api/V2/me
 * status_role - an auth2 role that allows traefiker to return information about running narratives from the /narrative_status/ endpoint for debugging (otherwise only timestamp and traefiker version is returned)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Any config key in the cfg dictionary in app.py can be overridden by an environme
 
 * narrative_version_url - a URL that returns the current version of the narrative.
 * image_name - the name of the image to be used to spawn narrative services in Rancher.  DO NOT include a :tag in this name.
-* image_tag - an optional variable to hardcode an image tag to use (omit the ':').  If not specified, defaults to whatever is returned by `narrative_version_url`.  Do not define image_tag with an empty value or otherwise bad value (e.g., whitespace) or the services traefiker attempts to spin up will break.
+* image_tag - an optional variable to hardcode an image tag to use (omit the ':').  If not specified, defaults to whatever is returned by `narrative_version_url`.  Do not define image_tag with an empty value or otherwise bad value (e.g., whitespace) or the services traefiker attempts to spin up may break.
 * auth2 - a valid URL to /api/V2/me
 * status_role - an auth2 role that allows traefiker to return information about running narratives from the /narrative_status/ endpoint for debugging (otherwise only timestamp and traefiker version is returned)
 

--- a/app.py
+++ b/app.py
@@ -16,19 +16,19 @@ from typing import Dict, List, Optional
 import ipaddress
 import sqlite3
 
-VERSION = "0.9.11"
+VERSION = "0.10.1"
 
 # Setup default configuration values, overriden by values from os.environ later
 cfg = {"docker_url": u"unix://var/run/docker.sock",    # path to docker socket
        "hostname": [u"localhost"],                     # hostname used for traefik router rules
        "auth2": u"https://ci.kbase.us/services/auth/api/V2/me",  # url for authenticating tokens
-       "image": u"kbase/narrative:latest",             # image name used for spawning narratives
+       "image_name": u"kbase/narrative",               # image name (omit :tag!) used for spawning narratives
+       "image_tag": None,                              # image tag; if not None, will be concatenated to image_name for new instances (otherwise narr_last_version will be used)
        "session_cookie": u"narrative_session",         # name of cookie used for storing session id
        "kbase_cookie": u"kbase_session",               # name of the cookie container kbase auth token
        "container_name": u"narrative-{}",              # python string template for narrative name, userid in param
        "container_name_prespawn": u"narrativepre-{}",  # python string template for pre-spawned narratives, userid in param
        "narrative_version_url": "https://ci.kbase.us/narrative_version",  # url to narrative_version endpoint
-       "narr_img": "kbase/narrative",                  # string used to match images of services/containers for reaping
        "traefik_metrics": "http://traefik:8080/metrics",  # URL of traefik metrics endpoint, api + prometheus must be enabled
        "dock_net": u"narrative-traefiker_default",     # name of the docker network that docker containers should be bound to
        "log_level": logging.DEBUG,                     # loglevel - DEBUG=10, INFO=20, WARNING=30, ERROR=40, CRITICAL=50
@@ -432,9 +432,9 @@ def get_active_traefik_svcs(narr_activity) -> Dict[str, time.time]:
                     logger.debug({"message": "websocket line: {}".format(line)})
                     containers[match.group(1)] = int(match.group(2))
             prefix = cfg['container_name'].format('')
-            logger.debug({"message": "Looking for containers that with name prefix {} and image name {}".format(prefix, cfg['narr_img'])})
-            # query for all of services in the environment that match cfg['narr_img'] as the image name
-            all_narr_containers = find_narratives(cfg['narr_img'])
+            logger.debug({"message": "Looking for containers that with name prefix {} and image name {}".format(prefix, cfg['image_name'])})
+            # query for all of services in the environment that match cfg['image_name'] as the image name
+            all_narr_containers = find_narratives(cfg['image_name'])
             # filter it down to only containers with the proper prefix
             narr_containers = [name for name in all_narr_containers if name.startswith(prefix)]
             logger.debug({"message": "Results from find_narratives", "containers": all_narr_containers})

--- a/app.py
+++ b/app.py
@@ -22,8 +22,8 @@ VERSION = "0.10.1"
 cfg = {"docker_url": u"unix://var/run/docker.sock",    # path to docker socket
        "hostname": [u"localhost"],                     # hostname used for traefik router rules
        "auth2": u"https://ci.kbase.us/services/auth/api/V2/me",  # url for authenticating tokens
-       "image_name": u"kbase/narrative",               # image name (omit :tag!) used for spawning narratives
-       "image_tag": None,                              # image tag; if not None, will be concatenated to image_name for new instances (otherwise narr_last_version will be used)
+       "image_name": u"kbase/narrative",               # image name (omit :tag !) used for spawning narratives
+       "image_tag": None,                              # image tag; if not None, will be concatenated to image_name for new instances (otherwise latest_narr_version() will be used)
        "session_cookie": u"narrative_session",         # name of cookie used for storing session id
        "kbase_cookie": u"kbase_session",               # name of the cookie container kbase auth token
        "container_name": u"narrative-{}",              # python string template for narrative name, userid in param

--- a/app.py
+++ b/app.py
@@ -248,10 +248,10 @@ def setup_app(app: flask.Flask) -> None:
     narr_activity.update(narr_time)
 
     logger.info({'message': "using sqlite3 database in {}".format(cfg['sqlite_reaperdb_path'])})
-    if (cfg['image_tag'] is not None and cfg['image_tag'].strip() != ''):
-        logger.info({'message': "no image_tag specified, will use version from URL {} for image name {}".format(cfg['narrative_version_url'],cfg['image_name'])})
-    else:
+    if (cfg['image_tag'] is not None and cfg['image_tag'] != ''):
         logger.info({'message': "image_tag specified, will use image {}:{}".format(cfg['image_name'],cfg['image_tag'])})
+    else:
+        logger.info({'message': "no image_tag specified, will use version from URL {} for image name {}".format(cfg['narrative_version_url'],cfg['image_name'])})
     try:
         # need this because we are not in a flask request context here
         with app.app_context():

--- a/app.py
+++ b/app.py
@@ -94,7 +94,7 @@ def merge_env_cfg() -> None:
             elif isinstance(cfg[cfg_item], list):
                 cfg[cfg_item] = os.environ[cfg_item].split(',')
             else:
-                cfg[cfg_item] = os.environ[cfg_item]
+                cfg[cfg_item] = os.environ[cfg_item].strip()
             logger.info({"message": "config set",
                          "key": cfg_item, "value": cfg[cfg_item]})
 

--- a/app.py
+++ b/app.py
@@ -248,6 +248,10 @@ def setup_app(app: flask.Flask) -> None:
     narr_activity.update(narr_time)
 
     logger.info({'message': "using sqlite3 database in {}".format(cfg['sqlite_reaperdb_path'])})
+    if (cfg['image_tag'] is not None and cfg['image_tag'].strip() != ''):
+        logger.info({'message': "no image_tag specified, will use version from URL {} for image name {}".format(cfg['narrative_version_url'],cfg['image_name'])})
+    else:
+        logger.info({'message': "image_tag specified, will use image {}:{}".format(cfg['image_name'],cfg['image_tag'])})
     try:
         # need this because we are not in a flask request context here
         with app.app_context():

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -6,7 +6,7 @@ import random
 import flask
 from datetime import datetime
 from typing import Dict, List, Optional
-
+import app
 
 # Module wide logger
 logger: Optional[logging.Logger] = None
@@ -61,23 +61,6 @@ def setup(main_cfg: dict, main_logger: logging.Logger) -> None:
                 cfg['narrenv'][match.group(1)] = os.environ[k]
                 logger.debug({"message": "Setting narrenv from environment",
                               "key": match.group(1), "value": os.environ[k]})
-
-# to do: figure out how to use method defined in app.py instead
-def latest_narr_version() -> str:
-    """
-    Queries cfg['narrative_revsion'] and returns the version string. Throws exception if there is a problem.
-    """
-    try:
-        r = requests.get(cfg['narrative_version_url'])
-        resp = r.json()
-        if r.status_code == 200:
-            version = resp['version']
-        else:
-            raise(Exception("Error querying {} for version: {} {}".format(cfg['narrative_version_url'],
-                            r.status_code, r.text)))
-    except Exception as err:
-        raise(err)
-    return(version)
 
 
 def check_session(userid: str) -> str:
@@ -306,7 +289,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     if (cfg['image_tag'] is not None):
         imageUuid = "{}:{}".format(cfg['image_name'], cfg['image_tag'])
     else:
-        imageUuid = "{}:{}".format(cfg['image_name'], latest_narr_version())
+        imageUuid = "{}:{}".format(cfg['image_name'], app.latest_narr_version())
     container_config['launchConfig']['imageUuid'] = "docker:{}".format(imageUuid)
     container_config['launchConfig']['environment'].update(cfg['narrenv'])
     container_config['name'] = name

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -180,7 +180,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
                         u'launchConfig':   {
                             u'blkioWeight': None,
                             u'capAdd': [],
-                            u'capDrop': ["MKNOD", "NET_RAW", "SYS_CHROOT", "SETUID", "SETGID", "CHOWN", "SYS_ADMIN", "BPF",
+                            u'capDrop': ["MKNOD", "NET_RAW", "SYS_CHROOT", "SETUID", "SETGID", "CHOWN",
                                          "DAC_OVERRIDE", "FOWNER", "FSETID", "SETPCAP", "AUDIT_WRITE", "SETFCAP"],
                             u'cgroupParent': None,
                             u'count': None,

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -6,6 +6,7 @@ import random
 import flask
 from datetime import datetime
 from typing import Dict, List, Optional
+# to do: move latest_narr_version() so we don't need to import app
 import app
 
 # Module wide logger
@@ -286,9 +287,10 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     labels["traefik.http.routers." + userid + ".entrypoints"] = u"web"
     container_config['launchConfig']['labels'] = labels
     container_config['launchConfig']['name'] = name
-    if (cfg['image_tag'] is not None):
+    if (cfg['image_tag'] is not None and cfg['image_tag'] != ''):
         imageUuid = "{}:{}".format(cfg['image_name'], cfg['image_tag'])
     else:
+        # to do: fix calling latest_narr_version() so we don't need to call the `app` method like this
         imageUuid = "{}:{}".format(cfg['image_name'], app.latest_narr_version())
     container_config['launchConfig']['imageUuid'] = "docker:{}".format(imageUuid)
     container_config['launchConfig']['environment'].update(cfg['narrenv'])

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -14,7 +14,8 @@ logger: Optional[logging.Logger] = None
 # Setup default configuration values, overriden by values from os.environ later
 cfg = {"hostname": u"localhost",
        "auth2": u"https://ci.kbase.us/services/auth/api/V2/token",
-       "image": u"kbase/narrative:latest",
+       "image_name": u"kbase/narrative",
+       "image_tag": None,
        "es_type": "narrative-traefiker",
        "session_cookie": u"narrative_session",
        "container_name": u"narrative-{}",
@@ -285,7 +286,11 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     labels["traefik.http.routers." + userid + ".entrypoints"] = u"web"
     container_config['launchConfig']['labels'] = labels
     container_config['launchConfig']['name'] = name
-    container_config['launchConfig']['imageUuid'] = "docker:{}".format(cfg['image'])
+    if (cfg['image_tag'] is not None):
+          imageUuid = cfg['image_name'] + ':' + cfg['image_tag']
+    else
+          imageUuid = cfg['image_name'] + ':' + narr_last_version
+    container_config['launchConfig']['imageUuid'] = "docker:{}".format(imageUuid)
     container_config['launchConfig']['environment'].update(cfg['narrenv'])
     container_config['name'] = name
     container_config['stackId'] = cfg['rancher_stack_id']
@@ -294,7 +299,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     # an error state, and overwrite the response with an error response
     try:
         r = requests.post(cfg["rancher_env_url"]+"/service", json=container_config, auth=(cfg["rancher_user"], cfg["rancher_password"]))
-        logger.info({"message": "new_container", "image": cfg['image'], "userid": userid, "service_name": name, "session_id": session,
+        logger.info({"message": "new_container", "image": imageUuid, "userid": userid, "service_name": name, "session_id": session,
                     "client_ip": client_ip})  # request.remote_addr)
         if not r.ok:
             msg = "Error - response code {} while creating new narrative rancher service: {}".format(r.status_code, r.text)
@@ -453,7 +458,7 @@ def find_narratives(image_name: Optional[str] = None) -> List[str]:
     given (the original function signature), then the default value of cfg['image'] is used.
     """
     if image_name is None:
-        image_name = cfg['image']
+        image_name = cfg['image_name']
     query_params = {'limit': 1000}
     url = "{}/stacks/{}/services".format(cfg['rancher_env_url'], cfg['rancher_stack_id'])
     r = requests.get(url, auth=(cfg['rancher_user'], cfg['rancher_password']), params=query_params)

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -62,6 +62,23 @@ def setup(main_cfg: dict, main_logger: logging.Logger) -> None:
                 logger.debug({"message": "Setting narrenv from environment",
                               "key": match.group(1), "value": os.environ[k]})
 
+# to do: figure out how to use method defined in app.py instead
+def latest_narr_version() -> str:
+    """
+    Queries cfg['narrative_revsion'] and returns the version string. Throws exception if there is a problem.
+    """
+    try:
+        r = requests.get(cfg['narrative_version_url'])
+        resp = r.json()
+        if r.status_code == 200:
+            version = resp['version']
+        else:
+            raise(Exception("Error querying {} for version: {} {}".format(cfg['narrative_version_url'],
+                            r.status_code, r.text)))
+    except Exception as err:
+        raise(err)
+    return(version)
+
 
 def check_session(userid: str) -> str:
     """

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -287,7 +287,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     labels["traefik.http.routers." + userid + ".entrypoints"] = u"web"
     container_config['launchConfig']['labels'] = labels
     container_config['launchConfig']['name'] = name
-    if (cfg['image_tag'] is not None and cfg['image_tag'] != ''):
+    if (cfg['image_tag'] is not None and cfg['image_tag'].strip() != ''):
         imageUuid = "{}:{}".format(cfg['image_name'], cfg['image_tag'])
     else:
         # to do: fix calling latest_narr_version() so we don't need to call the `app` method like this

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -286,10 +286,10 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     labels["traefik.http.routers." + userid + ".entrypoints"] = u"web"
     container_config['launchConfig']['labels'] = labels
     container_config['launchConfig']['name'] = name
-    if (cfg['image_tag'] is not None):
-        imageUuid = "{}:{}".format(cfg['image_name'], cfg['image_tag'])
-    else
-        imageUuid = "{}:{}".format(cfg['image_name'], narr_last_version)
+#    if (cfg['image_tag'] is not None):
+    imageUuid = "{}:{}".format(cfg['image_name'], cfg['image_tag'])
+#    else
+#        imageUuid = "{}:{}".format(cfg['image_name'], narr_last_version)
     container_config['launchConfig']['imageUuid'] = "docker:{}".format(imageUuid)
     container_config['launchConfig']['environment'].update(cfg['narrenv'])
     container_config['name'] = name

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -288,7 +288,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     container_config['launchConfig']['name'] = name
     if (cfg['image_tag'] is not None):
         imageUuid = "{}:{}".format(cfg['image_name'], cfg['image_tag'])
-    else
+    else:
         imageUuid = "{}:{}".format(cfg['image_name'], narr_last_version)
     container_config['launchConfig']['imageUuid'] = "docker:{}".format(imageUuid)
     container_config['launchConfig']['environment'].update(cfg['narrenv'])

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -287,7 +287,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     labels["traefik.http.routers." + userid + ".entrypoints"] = u"web"
     container_config['launchConfig']['labels'] = labels
     container_config['launchConfig']['name'] = name
-    if (cfg['image_tag'] is not None and cfg['image_tag'].strip() != ''):
+    if (cfg['image_tag'] is not None and cfg['image_tag'] != ''):
         imageUuid = "{}:{}".format(cfg['image_name'], cfg['image_tag'])
     else:
         # to do: fix calling latest_narr_version() so we don't need to call the `app` method like this

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -306,7 +306,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     if (cfg['image_tag'] is not None):
         imageUuid = "{}:{}".format(cfg['image_name'], cfg['image_tag'])
     else:
-        imageUuid = "{}:{}".format(cfg['image_name'], narr_last_version)
+        imageUuid = "{}:{}".format(cfg['image_name'], latest_narr_version())
     container_config['launchConfig']['imageUuid'] = "docker:{}".format(imageUuid)
     container_config['launchConfig']['environment'].update(cfg['narrenv'])
     container_config['name'] = name

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -287,9 +287,9 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     container_config['launchConfig']['labels'] = labels
     container_config['launchConfig']['name'] = name
     if (cfg['image_tag'] is not None):
-          imageUuid = cfg['image_name'] + ':' + cfg['image_tag']
+        imageUuid = "{}:{}".format(cfg['image_name'], cfg['image_tag'])
     else
-          imageUuid = cfg['image_name'] + ':' + narr_last_version
+        imageUuid = "{}:{}".format(cfg['image_name'], narr_last_version)
     container_config['launchConfig']['imageUuid'] = "docker:{}".format(imageUuid)
     container_config['launchConfig']['environment'].update(cfg['narrenv'])
     container_config['name'] = name

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -164,7 +164,7 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
                         u'launchConfig':   {
                             u'blkioWeight': None,
                             u'capAdd': [],
-                            u'capDrop': ["MKNOD", "NET_RAW", "SYS_CHROOT", "SETUID", "SETGID", "CHOWN",
+                            u'capDrop': ["MKNOD", "NET_RAW", "SYS_CHROOT", "SETUID", "SETGID", "CHOWN", "SYS_ADMIN",
                                          "DAC_OVERRIDE", "FOWNER", "FSETID", "SETPCAP", "AUDIT_WRITE", "SETFCAP"],
                             u'cgroupParent': None,
                             u'count': None,

--- a/manage_rancher.py
+++ b/manage_rancher.py
@@ -286,10 +286,10 @@ def start_new(session: str, userid: str, prespawn: Optional[bool] = False):
     labels["traefik.http.routers." + userid + ".entrypoints"] = u"web"
     container_config['launchConfig']['labels'] = labels
     container_config['launchConfig']['name'] = name
-#    if (cfg['image_tag'] is not None):
-    imageUuid = "{}:{}".format(cfg['image_name'], cfg['image_tag'])
-#    else
-#        imageUuid = "{}:{}".format(cfg['image_name'], narr_last_version)
+    if (cfg['image_tag'] is not None):
+        imageUuid = "{}:{}".format(cfg['image_name'], cfg['image_tag'])
+    else
+        imageUuid = "{}:{}".format(cfg['image_name'], narr_last_version)
     container_config['launchConfig']['imageUuid'] = "docker:{}".format(imageUuid)
     container_config['launchConfig']['environment'].update(cfg['narrenv'])
     container_config['name'] = name


### PR DESCRIPTION
By default, use the version returned by the configured narrative_version_url as the tag for new images.

If `image_tag` is configured, use that as the tag, ignoring narrative_version_url.